### PR TITLE
Make bundle compatible with SF2.5

### DIFF
--- a/Processors/Monolog/DeamonLoggerExtraWebProcessor.php
+++ b/Processors/Monolog/DeamonLoggerExtraWebProcessor.php
@@ -93,7 +93,7 @@ class DeamonLoggerExtraWebProcessor extends BaseWebProcessor
     private function addUserInfo()
     {
         if ($this->configShowExtraInfo('user')) {
-            $token = $this->container->get('security.token_storage')->getToken();
+            $token = $this->container->get('security.context')->getToken();
             if (($token instanceof TokenInterface) && ($token->getUser() instanceof UserInterface) && null !== $user = $token->getUser()) {
                 if ($this->configShowExtraInfo('user_id') && method_exists($user, 'getId')) {
                     $this->record['extra']['user_id'] = $user->getId();

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,14 @@
         "gelf"
     ],
     "require" : {
+
         "php": ">=5.5",
-        "symfony/security": "^2.7||^3.0",
-        "symfony/dependency-injection": "^2.7||^3.0",
-        "symfony/monolog-bridge": "^2.7||^3.0",
-        "symfony/http-foundation": "^2.7||^3.0",
-        "symfony/http-kernel": "^2.7||^3.0",
-        "symfony/config": "^2.7||^3.0"
+        "symfony/security": "^2.5",
+        "symfony/dependency-injection": "^2.5",
+        "symfony/monolog-bridge": "^2.5",
+        "symfony/http-foundation": "^2.5",
+        "symfony/http-kernel": "^2.5",
+        "symfony/config": "^2.5"
     },
     "require-dev" : {
         "phpunit/phpunit": "^4.8||^5.4.3",


### PR DESCRIPTION
Replaced "security.token_storage" with "security.context" (and associated methods)

Removed compatibility with Symfony 3.0