### PR TITLE
Add sf5 and php 7.4 compatibility 

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,3 +9,6 @@ build:
                 coverage:
                     file: 'clover-coverage.xml'
                     format: 'clover'
+    environment:
+        php:
+            version: 7.2  # or any other released version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-sudo: false
+
 cache:
     directories:
     - $HOME/.composer/cache/files
@@ -10,22 +10,23 @@ env:
     - PHPUNIT_FLAGS="-v"
     - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
 
-matrix:
+jobs:
     fast_finish: true
     include:
     # Minimum supported dependencies with the latest and oldest PHP version
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
     - php: 7.2
-      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
-    - php: 7.1
-      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
 
     # Test the latest stable release
-    - php: 7.1
     - php: 7.2
+    - php: 7.3
+    - php: 7.4
       env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
 
     # Latest commit to master
-    - php: 7.2
+    - php: 7.4
       env: STABILITY="dev"
 
     allow_failures:

--- a/Processors/Monolog/DeamonLoggerExtraWebProcessor.php
+++ b/Processors/Monolog/DeamonLoggerExtraWebProcessor.php
@@ -59,10 +59,18 @@ class DeamonLoggerExtraWebProcessor extends BaseWebProcessor
     public function __construct(?array $config = null)
     {
         parent::__construct([]);
-        $this->channelPrefix = $config['channel_prefix'];
-        $this->displayConfig = $config['display'];
-        $this->userClass = $config['user_class'];
-        $this->userMethods = $config['user_methods'];
+        if(!empty($config) && array_key_exists('channel_prefix', $config)) {
+            $this->channelPrefix = $config['channel_prefix'];
+        }
+        if(!empty($config) && array_key_exists('display', $config)) {
+            $this->displayConfig = $config['display'];
+        }
+        if(!empty($config) && array_key_exists('user_class', $config)) {
+            $this->userClass = $config['user_class'];
+        }
+        if(!empty($config) && array_key_exists('user_methods', $config)) {
+            $this->userMethods = $config['user_methods'];
+        }
     }
 
     /**
@@ -70,7 +78,7 @@ class DeamonLoggerExtraWebProcessor extends BaseWebProcessor
      *
      * @return array
      */
-    public function __invoke(array $record)
+    public function __invoke(array $record): array
     {
         $this->record = parent::__invoke($record);
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ DeamonLoggerExtra Bundle
 [![Build Status](https://travis-ci.org/FrDeamon/logger-extra-bundle.svg?branch=master&style=flat)](https://travis-ci.org/FrDeamon/logger-extra-bundle)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/FrDeamon/logger-extra-bundle/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/FrDeamon/logger-extra-bundle/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/FrDeamon/logger-extra-bundle/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/FrDeamon/logger-extra-bundle/?branch=master)
-![symfony version](https://img.shields.io/badge/symfony->=4.0-blue.svg)
-![php version](https://img.shields.io/badge/php->=7.1-blue.svg)
+![symfony version](https://img.shields.io/badge/symfony->=5.0-blue.svg)
+![php version](https://img.shields.io/badge/php->=7.2-blue.svg)
 
 
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/5a913c84-a190-40f7-9e46-3c2052692fcd/big.png)](https://insight.sensiolabs.com/projects/5a913c84-a190-40f7-9e46-3c2052692fcd)
@@ -17,7 +17,7 @@ If you need compatibility with previous Symfony versions, have a look at previou
 
 Requirements
 ----------------
-php >=7.1
+php >=7.2
 
 symfony/security-core
 symfony/dependency-injection
@@ -26,7 +26,7 @@ symfony/http-kernel
 symfony/http-foundation
 symfony/config
 
-Compatible with Symfony starting from 4.0
+Compatible with Symfony starting from 5.0
 
 Installation
 ----------------
@@ -34,7 +34,7 @@ Installation
 You need to add a package to your dependency list :
 ```
     // composer.json
-    "deamon/logger-extra-bundle": "^4.0"
+    "deamon/logger-extra-bundle": "^5.0"
 ```
 
 Then enable the bundle into your kernel

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
     ],
     "require": {
         "php": ">=7.1",
-        "symfony/security-core": "^4.0",
-        "symfony/dependency-injection": "^4.0",
-        "symfony/monolog-bridge": "^4.0",
-        "symfony/http-kernel": "^4.0",
-        "symfony/http-foundation": "^4.0",
-        "symfony/config": "^4.0"
+        "symfony/security-core": "^5.0",
+        "symfony/dependency-injection": "^5.0",
+        "symfony/monolog-bridge": "^5.0",
+        "symfony/http-kernel": "^5.0",
+        "symfony/http-foundation": "^5.0",
+        "symfony/config": "^5.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.0"
+        "symfony/phpunit-bridge": "^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.1-dev"
+            "dev-master": "5.0.x-dev"
         }
     },
     "suggest": {


### PR DESCRIPTION
Dans le composer.json nous avons passé tous les composant symfony en ^5.0.
Les fichiers travis.yml et scrutinizer.yml ont été modifiés en conséquence.