### PR TITLE
Fix for user methods not attached becuase of tokenStorageInterface

### DIFF
--- a/Processors/Monolog/DeamonLoggerExtraWebProcessor.php
+++ b/Processors/Monolog/DeamonLoggerExtraWebProcessor.php
@@ -137,7 +137,7 @@ class DeamonLoggerExtraWebProcessor extends BaseWebProcessor
             return;
         }
 
-        if (!$this->tokenStorage instanceof TokenStorage) {
+        if (!$this->tokenStorage instanceof TokenStorageInterface) {
             return;
         }
 


### PR DESCRIPTION
User methods not attached to log data because of $tokenStorage is not correctly checked against TokenStorageInterface ... tested in Symfony 4.4  