### PR TITLE
[Bug] Fix monolog version conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=8.0.2",
         "symfony/security-core": "^6.0",
         "symfony/dependency-injection": "^6.0",
-        "symfony/monolog-bridge": "^6.0",
+        "symfony/monolog-bridge": "6.0.*",
         "symfony/http-kernel": "^6.0",
         "symfony/http-foundation": "^6.0",
         "symfony/config": "^6.0"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "php": ">=8.0.2",
         "symfony/security-core": "^6.0",
         "symfony/dependency-injection": "^6.0",
-        "symfony/monolog-bridge": "6.0.*",
+        "symfony/monolog-bridge": "^6.0",
+        "monolog/monolog": "^2.0",
         "symfony/http-kernel": "^6.0",
         "symfony/http-foundation": "^6.0",
         "symfony/config": "^6.0"


### PR DESCRIPTION
`symfony/monolog-bridge` 6.1 requires `monolog/monolog` 3.X which change `__invoke()` method signature.
Limit version of `monolog/monolog` to 2.X.